### PR TITLE
Implement Expo QR code scanner

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,20 +1,116 @@
+import React, { useState, useEffect } from 'react';
+import { StyleSheet, Text, View, Button, FlatList, Linking } from 'react-native';
+import { BarCodeScanner } from 'expo-barcode-scanner';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
 
 export default function App() {
+  const [hasPermission, setHasPermission] = useState(null);
+  const [scanned, setScanned] = useState(false);
+  const [history, setHistory] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await BarCodeScanner.requestPermissionsAsync();
+      setHasPermission(status === 'granted');
+    })();
+  }, []);
+
+  const handleBarCodeScanned = ({ type, data }) => {
+    setScanned(true);
+    const entry = { id: Date.now().toString(), type, data };
+    setHistory((current) => [entry, ...current]);
+  };
+
+  if (hasPermission === null) {
+    return (
+      <View style={styles.centered}>
+        <Text>Requesting camera permission...</Text>
+      </View>
+    );
+  }
+
+  if (hasPermission === false) {
+    return (
+      <View style={styles.centered}>
+        <Text>No access to camera</Text>
+      </View>
+    );
+  }
+
+  const last = history[0];
+
   return (
     <View style={styles.container}>
-      <Text>Open up App.js to start working on your app!</Text>
+      {!scanned && (
+        <BarCodeScanner
+          onBarCodeScanned={handleBarCodeScanned}
+          style={StyleSheet.absoluteFillObject}
+        />
+      )}
+      {scanned && (
+        <View style={styles.overlay}>
+          <Text style={styles.text}>Last Scan: {last?.data}</Text>
+          <Button title="Scan Again" onPress={() => setScanned(false)} />
+          {last && isValidUrl(last.data) && (
+            <Button title="Open Link" onPress={() => Linking.openURL(last.data)} />
+          )}
+          <Text style={styles.text}>Total scans: {history.length}</Text>
+        </View>
+      )}
+      <FlatList
+        data={history}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <Text style={styles.listItem}>{item.data}</Text>
+        )}
+        style={styles.list}
+      />
       <StatusBar style="auto" />
     </View>
   );
 }
 
+function isValidUrl(value) {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
+    backgroundColor: '#000',
+  },
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    paddingTop: 50,
     alignItems: 'center',
+  },
+  text: {
+    color: '#fff',
+    marginBottom: 8,
+  },
+  centered: {
+    flex: 1,
     justifyContent: 'center',
+    alignItems: 'center',
+  },
+  list: {
+    position: 'absolute',
+    bottom: 0,
+    width: '100%',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  listItem: {
+    color: '#fff',
+    padding: 4,
+    textAlign: 'center',
   },
 });
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# barcode-scanner
+# Barcode Scanner Expo App
+
+This React Native application demonstrates QR code scanning using Expo. It keeps
+track of all scanned codes and allows you to open URLs directly if the scanned
+data is a valid link.
+
+## Development
+
+1. Install dependencies with `npm install`.
+2. Start the development server:
+
+   ```bash
+   npm start
+   ```
+
+3. Use the Expo Go app or an emulator to run the application.
+

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "expo": "~53.0.10",
     "expo-status-bar": "~2.2.3",
+    "expo-barcode-scanner": "~12.7.0",
     "react": "19.0.0",
     "react-native": "0.79.3"
   },


### PR DESCRIPTION
## Summary
- add expo-barcode-scanner dependency
- implement QR code scanning with history and link handling
- document running the app in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684348e77eb083329774d6bd4836cb66