### PR TITLE
Implement photo capture and gallery features

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,6 +5,8 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import ScannerScreen from './src/screens/ScannerScreen';
 import ResultScreen from './src/screens/ResultScreen';
 import HistoryScreen from './src/screens/HistoryScreen';
+import EditPhotoScreen from './src/screens/EditPhotoScreen';
+import GalleryScreen from './src/screens/GalleryScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -26,6 +28,16 @@ export default function App() {
           name="History"
           component={HistoryScreen}
           options={{ title: 'Історія' }}
+        />
+        <Stack.Screen
+          name="EditPhoto"
+          component={EditPhotoScreen}
+          options={{ title: 'Редагування' }}
+        />
+        <Stack.Screen
+          name="Gallery"
+          component={GalleryScreen}
+          options={{ title: 'Галерея' }}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/native-stack": "^7.3.14",
     "expo": "~53.0.10",
     "expo-camera": "^16.1.7",
+    "expo-image-manipulator": "^11.4.0",
     "expo-clipboard": "~7.1.4",
     "expo-sharing": "^13.1.5",
     "expo-status-bar": "~2.2.3",

--- a/src/screens/EditPhotoScreen.js
+++ b/src/screens/EditPhotoScreen.js
@@ -1,0 +1,83 @@
+import React, { useState, useRef } from 'react';
+import { View, Image, PanResponder, TouchableOpacity, Text } from 'react-native';
+import { manipulateAsync, SaveFormat } from 'expo-image-manipulator';
+
+import { styles } from '../styles';
+import { savePhoto } from '../utils';
+
+export default function EditPhotoScreen({ route, navigation }) {
+  const { photoUri } = route.params;
+  const [crop, setCrop] = useState(null);
+  const startRef = useRef(null);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onPanResponderGrant: (e) => {
+        const { locationX, locationY } = e.nativeEvent;
+        startRef.current = { x: locationX, y: locationY };
+        setCrop({ x: locationX, y: locationY, width: 0, height: 0 });
+      },
+      onPanResponderMove: (e) => {
+        if (!startRef.current) return;
+        const { locationX, locationY } = e.nativeEvent;
+        setCrop({
+          x: Math.min(startRef.current.x, locationX),
+          y: Math.min(startRef.current.y, locationY),
+          width: Math.abs(locationX - startRef.current.x),
+          height: Math.abs(locationY - startRef.current.y),
+        });
+      },
+      onPanResponderRelease: () => {
+        startRef.current = null;
+      },
+    })
+  ).current;
+
+  const cropAndSave = async () => {
+    let uri = photoUri;
+    if (crop && crop.width > 0 && crop.height > 0) {
+      const result = await manipulateAsync(
+        photoUri,
+        [
+          {
+            crop: {
+              originX: crop.x,
+              originY: crop.y,
+              width: crop.width,
+              height: crop.height,
+            },
+          },
+        ],
+        { compress: 1, format: SaveFormat.JPEG }
+      );
+      uri = result.uri;
+    }
+    await savePhoto(uri);
+    navigation.navigate('Gallery');
+  };
+
+  return (
+    <View style={styles.cropContainer}>
+      <View style={{ flex: 1 }} {...panResponder.panHandlers}>
+        <Image source={{ uri: photoUri }} style={styles.cropImage} resizeMode="contain" />
+        {crop && (
+          <View
+            style={[
+              styles.cropFrame,
+              { left: crop.x, top: crop.y, width: crop.width, height: crop.height },
+            ]}
+          />
+        )}
+      </View>
+      <View style={styles.cropActions}>
+        <TouchableOpacity style={styles.primaryBtn} onPress={cropAndSave}>
+          <Text style={styles.primaryBtnText}>Обрізати та зберегти</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.secondaryBtn} onPress={() => navigation.goBack()}>
+          <Text style={styles.secondaryBtnText}>Скасувати</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/src/screens/GalleryScreen.js
+++ b/src/screens/GalleryScreen.js
@@ -1,0 +1,48 @@
+import React, { useState, useCallback } from 'react';
+import { View, FlatList, Image, TouchableOpacity, Text } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { useFocusEffect } from '@react-navigation/native';
+
+import { styles } from '../styles';
+import { loadGallery, deletePhoto } from '../utils';
+
+export default function GalleryScreen() {
+  const [photos, setPhotos] = useState([]);
+
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        setPhotos(await loadGallery());
+      })();
+    }, [])
+  );
+
+  const remove = async (uri) => {
+    await deletePhoto(uri);
+    setPhotos(await loadGallery());
+  };
+
+  const renderItem = ({ item }) => (
+    <View style={styles.galleryItem}>
+      <Image source={{ uri: item }} style={styles.galleryImage} />
+      <TouchableOpacity style={styles.deleteBtn} onPress={() => remove(item)}>
+        <MaterialIcons name="delete" size={24} color="#fff" />
+      </TouchableOpacity>
+    </View>
+  );
+
+  return (
+    <View style={styles.galleryContainer}>
+      <FlatList
+        data={photos}
+        keyExtractor={(item) => item}
+        renderItem={renderItem}
+        ListEmptyComponent={
+          <View style={styles.centered}>
+            <Text style={styles.message}>Галерея порожня</Text>
+          </View>
+        }
+      />
+    </View>
+  );
+}

--- a/src/screens/ScannerScreen.js
+++ b/src/screens/ScannerScreen.js
@@ -20,6 +20,7 @@ export default function ScannerScreen({ navigation }) {
   const [scanned, setScanned] = useState(false);
   const [facing, setFacing] = useState('back');
   const [flash, setFlash] = useState('off');
+  const cameraRef = React.useRef(null);
   const frameAnim = React.useRef(new Animated.Value(0)).current;
 
   useFocusEffect(
@@ -80,9 +81,20 @@ export default function ScannerScreen({ navigation }) {
     setFlash((prev) => (prev === 'torch' ? 'off' : 'torch'));
   };
 
+  const openGallery = () => {
+    navigation.navigate('Gallery');
+  };
+
+  const takePhoto = async () => {
+    if (!cameraRef.current) return;
+    const photo = await cameraRef.current.takePictureAsync();
+    navigation.navigate('EditPhoto', { photoUri: photo.uri });
+  };
+
   return (
     <View style={styles.container}>
       <CameraView
+        ref={cameraRef}
         style={StyleSheet.absoluteFillObject}
         facing={facing}
         flash={flash}
@@ -107,6 +119,12 @@ export default function ScannerScreen({ navigation }) {
             onPress={() => navigation.navigate('History')}
           >
             <MaterialIcons name="history" size={28} color="#fff" />
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.iconBtn} onPress={openGallery}>
+            <MaterialIcons name="photo-library" size={28} color="#fff" />
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.iconBtn} onPress={takePhoto}>
+            <MaterialIcons name="photo-camera" size={28} color="#fff" />
           </TouchableOpacity>
         </View>
       </CameraView>

--- a/src/styles.js
+++ b/src/styles.js
@@ -34,7 +34,7 @@ export const styles = StyleSheet.create({
     right: 24,
     flexDirection: 'row',
     justifyContent: 'space-between',
-    width: 120,
+    width: 200,
   },
   iconBtn: {
     backgroundColor: '#00000044',
@@ -112,5 +112,44 @@ export const styles = StyleSheet.create({
     color: colors.gray,
     fontSize: 12,
     marginTop: 4,
+  },
+  galleryContainer: {
+    flex: 1,
+    backgroundColor: colors.background,
+    padding: 16,
+  },
+  galleryItem: {
+    marginBottom: 16,
+  },
+  galleryImage: {
+    width: '100%',
+    height: 200,
+    borderRadius: 8,
+  },
+  deleteBtn: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    backgroundColor: '#00000088',
+    borderRadius: 20,
+    padding: 4,
+  },
+  cropContainer: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  cropImage: {
+    flex: 1,
+  },
+  cropFrame: {
+    position: 'absolute',
+    borderWidth: 2,
+    borderColor: colors.accent,
+  },
+  cropActions: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    padding: 16,
+    backgroundColor: '#000',
   },
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export const HISTORY_KEY = 'scan_history';
+export const GALLERY_KEY = 'photo_gallery';
 
 export function snippet(text) {
   return text.length > 30 ? text.slice(0, 30) + '...' : text;
@@ -24,4 +25,21 @@ export async function saveHistory(entry) {
 export async function loadHistory() {
   const data = await AsyncStorage.getItem(HISTORY_KEY);
   return data ? JSON.parse(data) : [];
+}
+
+export async function savePhoto(uri) {
+  const list = await loadGallery();
+  list.unshift(uri);
+  await AsyncStorage.setItem(GALLERY_KEY, JSON.stringify(list));
+}
+
+export async function loadGallery() {
+  const data = await AsyncStorage.getItem(GALLERY_KEY);
+  return data ? JSON.parse(data) : [];
+}
+
+export async function deletePhoto(uri) {
+  const list = await loadGallery();
+  const filtered = list.filter((item) => item !== uri);
+  await AsyncStorage.setItem(GALLERY_KEY, JSON.stringify(filtered));
 }


### PR DESCRIPTION
## Summary
- add gallery and photo editing screens
- store photos and enable cropping
- capture photos from the scanner and open gallery
- update styles for new features
- include expo-image-manipulator dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68435ace871c8332946148da0cb4583d